### PR TITLE
feat: implement defaultLanguage & defaultLanguageAsFallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,19 +29,20 @@ var BlogPost = new Schema({
 Adding plugin to the schema:
 
 ```js
-BlogPost.plugin(mongooseIntl, { languages: ['en', 'de', 'fr'], defaultLanguage: 'en' });
+BlogPost.plugin(mongooseIntl, { languages: ['en', 'de', 'fr'], defaultLanguage: 'en', defaultLanguageAsFallback: false });
 ```
 
 or it can be defined as a global plugin which will be applied to all schemas:
 
 ```js
-mongoose.plugin(mongooseIntl, { languages: ['en', 'de', 'fr'], defaultLanguage: 'en' });
+mongoose.plugin(mongooseIntl, { languages: ['en', 'de', 'fr'], defaultLanguage: 'en', defaultLanguageAsFallback: false });
 ```
 
 ### Plugin options
 
 * languages - required, array with languages, suggested to use 2- or 3-letters language codes using [ISO 639 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
-* defaultLanguage - optional, if omitted the first value from `languages` array will be used as a default language
+* defaultLanguage - optional, if omitted the first value from `languages` array will be used as the default plugin language
+* defaultLanguageAsFallback - optional, disabled if omitted, allow to use the `defaultLanguage` as virtual getter fallback in case the value does not exist for the current language
 
 ### Database representation
 

--- a/lib/mongoose-intl.js
+++ b/lib/mongoose-intl.js
@@ -15,10 +15,17 @@ module.exports = exports = function mongooseIntl(schema, options) {
     pluginOptions.languages = options.languages.slice(0);
 
     // the first available language will be used as default if it's not set or unknown value passed
-    if (!options.defaultLanguage || pluginOptions.languages.indexOf(options.defaultLanguage) === -1) {
-        pluginOptions.defaultLanguage = pluginOptions.languages[0];
+    if (typeof options.defaultLanguage === 'string' && pluginOptions.languages.indexOf(options.defaultLanguage) !== -1) {
+        pluginOptions.defaultLanguage = options.defaultLanguage
     } else {
-        pluginOptions.defaultLanguage = options.defaultLanguage.slice(0);
+        pluginOptions.defaultLanguage = pluginOptions.languages[0];
+    }
+
+    // allow to use the default language as fallback in virtual getter, set to false if omitted
+    if (typeof options.defaultLanguageAsFallback === 'boolean') {
+        pluginOptions.defaultLanguageAsFallback = options.defaultLanguageAsFallback;
+    } else {
+        pluginOptions.defaultLanguageAsFallback = false;
     }
 
     schema.eachPath(function (path, schemaType) {
@@ -67,6 +74,13 @@ module.exports = exports = function mongooseIntl(schema, options) {
                     return langSubDoc[lang];
                 }
 
+                // allow to use the default language as fallback if enabled
+                if (pluginOptions.defaultLanguageAsFallback) {
+                  if (langSubDoc.hasOwnProperty(pluginOptions.defaultLanguage)) {
+                    return langSubDoc[pluginOptions.defaultLanguage];
+                  }
+                }
+
                 // are there any other languages defined?
                 for (var prop in langSubDoc) {
                     if (langSubDoc.hasOwnProperty(prop)) {
@@ -100,7 +114,7 @@ module.exports = exports = function mongooseIntl(schema, options) {
         intlObject[key] = {};
         pluginOptions.languages.forEach(function (lang) {
             var langOptions = extend({}, schemaType.options);
-            if (lang !== options.defaultLanguage) {
+            if (lang !== pluginOptions.defaultLanguage) {
                 delete langOptions.default;
                 delete langOptions.required;
             }


### PR DESCRIPTION
This pull request aims to provide two new options to the plugin.

- `defaultLanguage` - optional, if omitted the first value from languages array will be used as the default plugin language
- `defaultLanguageAsFallback` - optional, disabled if omitted, allow to use the defaultLanguage as virtual getter fallback in case the value does not exist for the current language

The first one let you choose a different defaultLanguage than the first language of the array (implemented mainly for the second one).
The second one implements a language fallback, so if there is no content for the current language, the default language is used a fallback.

I'm using the fork for multiple months without issue though I would pull request back, there is no tests written so I did not add any. Let me know if something is wrong and I will fix it.