### PR TITLE
Support Mongoose >=5.5.14

### DIFF
--- a/lib/mongoose-intl.js
+++ b/lib/mongoose-intl.js
@@ -57,7 +57,7 @@ module.exports = exports = function mongooseIntl(schema, options) {
                 // embedded and sub-documents will use language methods from the top level document
                 var owner = this.ownerDocument ? this.ownerDocument() : this,
                     lang = owner.getLanguage(),
-                    langSubDoc = this.getValue(path);
+                    langSubDoc = (this.$__getValue || this.getValue).call(this, path);
 
                 if (langSubDoc === null || langSubDoc === void 0) {
                     return langSubDoc;


### PR DESCRIPTION
The name of the internal Mongoose function `Document#getValue` changed in v5.5.14; adjust the plugin accordingly (maintaining compatibility with earlier versions).

See: https://github.com/Automattic/mongoose/pull/7870

Fixes #19.