### PR TITLE
Add fallback option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,6 @@ build/Release
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
 
-# IDE directory
+# IDE directories
 .idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ mongoose.plugin(mongooseIntl, { languages: ['en', 'de', 'fr'], defaultLanguage: 
 
 ### Plugin options
 
-* languages - required, array with languages, suggested to use 2- or 3-letters language codes using [ISO 639 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
-* defaultLanguage - optional, if omitted the first value from `languages` array will be used as a default language
+* `languages` - required, array with languages, suggested to use 2- or 3-letters language codes using [ISO 639 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
+* `defaultLanguage` - optional, if omitted the first value from `languages` array will be used as a default language
+* `fallback` - when `true`, another translation is returned for fields that are not available in the currently selected language, chosen according to the order of the `languages` option (default: `false`, i.e. fields with missing translation are returned as `null`)
 
 ### Database representation
 

--- a/lib/mongoose-intl.js
+++ b/lib/mongoose-intl.js
@@ -20,6 +20,7 @@ module.exports = exports = function mongooseIntl(schema, options) {
     } else {
         pluginOptions.defaultLanguage = options.defaultLanguage.slice(0);
     }
+    pluginOptions.fallback = 'fallback' in options ? options.fallback : false;
 
     schema.eachPath(function (path, schemaType) {
         if (schemaType.schema) { // propagate plugin initialization for sub-documents schemas
@@ -68,9 +69,9 @@ module.exports = exports = function mongooseIntl(schema, options) {
                 }
 
                 // are there any other languages defined?
-                for (var prop in langSubDoc) {
-                    if (langSubDoc.hasOwnProperty(prop)) {
-                        return null; // some other languages exist, but the required is not - return null value
+                for (lang of pluginOptions.languages) {
+                    if (langSubDoc.hasOwnProperty(lang)) {
+                        return pluginOptions.fallback ? langSubDoc[lang] : null;
                     }
                 }
                 return void 0; // no languages defined - the entire field is undefined


### PR DESCRIPTION
Add a new plugin option `fallback` that allows optionally returning
other translations for fields that are not available in the currently
set language.

Fixes #22.