### PR TITLE
Send full language object with virtuals.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # mongoose-intl
+
 Mongoose schema plugin for multilingual fields
 
 ## Installation
@@ -14,34 +15,41 @@ $ npm install mongoose-intl --save
 Schema definition with `intl` option enabled for some fields:
 
 ```js
-var mongoose     = require('mongoose'),
-    mongooseIntl = require('mongoose-intl'),
-    Schema       = mongoose.Schema;
+var mongoose = require('mongoose'),
+  mongooseIntl = require('mongoose-intl'),
+  Schema = mongoose.Schema;
 
 var BlogPost = new Schema({
-    title  : { type: String, intl: true },
-    body   : { type: String, intl: true }
+  title: { type: String, intl: true },
+  body: { type: String, intl: true }
 });
 ```
 
-*Note:* `intl` option can be enabled for String type only.
+_Note:_ `intl` option can be enabled for String type only.
 
 Adding plugin to the schema:
 
 ```js
-BlogPost.plugin(mongooseIntl, { languages: ['en', 'de', 'fr'], defaultLanguage: 'en' });
+BlogPost.plugin(mongooseIntl, {
+  languages: ['en', 'de', 'fr'],
+  defaultLanguage: 'en'
+});
 ```
 
 or it can be defined as a global plugin which will be applied to all schemas:
 
 ```js
-mongoose.plugin(mongooseIntl, { languages: ['en', 'de', 'fr'], defaultLanguage: 'en' });
+mongoose.plugin(mongooseIntl, {
+  languages: ['en', 'de', 'fr'],
+  defaultLanguage: 'en'
+});
 ```
 
 ### Plugin options
 
-* languages - required, array with languages, suggested to use 2- or 3-letters language codes using [ISO 639 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
-* defaultLanguage - optional, if omitted the first value from `languages` array will be used as a default language
+- languages - required, array with languages, suggested to use 2- or 3-letters language codes using [ISO 639 standard](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)
+- defaultLanguage - optional, if omitted the first value from `languages` array will be used as a default language
+- virtualObject - optional, if true will send the full translate object with .toObject() and .toJson()
 
 ### Database representation
 
@@ -68,7 +76,7 @@ mongoose.plugin(mongooseIntl, { languages: ['en', 'de', 'fr'], defaultLanguage: 
 `intl`-enabled field is converted to a virtual path and continue interacting as a string, not an object.
 It means that you can read it and write to it any string, and it will be stored under default language setting.
 
-Other languages values can be set by using `model.set()` method. Pass an object with multiple languages instead of the string to set all values together. See examples below. 
+Other languages values can be set by using `model.set()` method. Pass an object with multiple languages instead of the string to set all values together. See examples below.
 
 Multilingual fields can be set with 3 ways:
 
@@ -81,17 +89,17 @@ post.title = 'Title on default language'; // default language definition, will b
 
 post.set('title.de', 'German title'); // any other language value definition
 
-post.title = { // defines all languages in one call using an object
-    en: 'Title on default language',
-    de: 'Another German title',
-    fr: 'French title'
+post.title = {
+  // defines all languages in one call using an object
+  en: 'Title on default language',
+  de: 'Another German title',
+  fr: 'French title'
 };
 
-post.save(function (err) {
-    if (err) return handleError(err);
-    res.send(post);
+post.save(function(err) {
+  if (err) return handleError(err);
+  res.send(post);
 });
-
 ```
 
 Values can be read using the same options:
@@ -99,20 +107,20 @@ Values can be read using the same options:
 ```js
 var BlogPostModel = mongoose.model('Post', BlogPost);
 
-BlogPostModel.findById('some id', function (err, post) {
+BlogPostModel.findById('some id', function(err, post) {
   if (err) return handleError(err);
-  
-  post.title; // 'Title on default language'
-  
-  post.get('title.de'); // 'Another German title'  
-});
 
+  post.title; // 'Title on default language'
+
+  post.get('title.de'); // 'Another German title'
+});
 ```
 
 #### Returning the whole document
 
 The main `intl`-field defined as a virtual, and it will not be returned by `toJSON/toObject` methods which are used during the document conversion to JSON or object.
 So you'll get the following result be default:
+
 ```js
 console.log(post.toJSON());
 
@@ -157,83 +165,92 @@ console.log(post.toJSON());
 ### Language methods
 
 The current language can be set/changed on 3 levels:
-* Document level: affects only some document (each particular model instance)
-* Schema level: affects all documents created from the models with the particular schema
-* Connection level: affects all models (and their schemas) created for the particular Mongoose connection
+
+- Document level: affects only some document (each particular model instance)
+- Schema level: affects all documents created from the models with the particular schema
+- Connection level: affects all models (and their schemas) created for the particular Mongoose connection
 
 #### Document level
 
 Each document will receive the following language methods:
-* `getLanguages()` - returns an array of available languages
-* `getLanguage()` - returns current document's language
-* `setLanguage(lang)` - changes document's language to a new one, the value should be equal to the one of available languages
-* `unsetLanguage()` - removes previously set document-specific language, schema's default language will be used for the translation
+
+- `getLanguages()` - returns an array of available languages
+- `getLanguage()` - returns current document's language
+- `setLanguage(lang)` - changes document's language to a new one, the value should be equal to the one of available languages
+- `unsetLanguage()` - removes previously set document-specific language, schema's default language will be used for the translation
 
 Usage examples:
 
 ```js
-BlogPostModel.find({}, function (err, posts) {
+BlogPostModel.find({}, function(err, posts) {
   if (err) return handleError(err);
-  
+
   console.log(JSON.stringify(posts)); // [{ _id: '...', title: 'Title 1 on default language' },
-                                      //  { _id: '...', title: 'Title 2 on default language' }, ...]
-  
+  //  { _id: '...', title: 'Title 2 on default language' }, ...]
+
   posts[0].getLanguages(); // [ 'en', 'de', 'fr' ]
   posts[0].getLanguage(); // 'en'
-  
+
   posts[0].setLanguage('de');
   console.log(JSON.stringify(posts)); // [{ _id: '...', title: 'Another German title' },
-                                      //  { _id: '...', title: 'Title 2 on default language' }, ...]
-  
+  //  { _id: '...', title: 'Title 2 on default language' }, ...]
+
   BlogPostModel.setDefaultLanguage('fr'); // schema-level language change (see documentation below)
   console.log(JSON.stringify(posts)); // [{ _id: '...', title: 'Another German title' }, // still 'de'
-                                      //  { _id: '...', title: 'French title 2' }, ...]
-  
+  //  { _id: '...', title: 'French title 2' }, ...]
+
   posts[0].unsetLanguage();
   console.log(JSON.stringify(posts)); // [{ _id: '...', title: 'French title 1' },
-                                      //  { _id: '...', title: 'French title 2' }, ...]
+  //  { _id: '...', title: 'French title 2' }, ...]
 });
 ```
 
 #### Schema level
 
 The plugins adds the following language methods to the schema:
-* `getLanguages()` - returns an array of available languages
-* `getDefaultLanguage()` - returns current default language
-* `setDefaultLanguage(lang)` - changes default language to a new one, the value should be equal to the one of available languages
+
+- `getLanguages()` - returns an array of available languages
+- `getDefaultLanguage()` - returns current default language
+- `setDefaultLanguage(lang)` - changes default language to a new one, the value should be equal to the one of available languages
 
 Usage examples:
 
 ```js
-BlogPostModel.find({}, function (err, posts) {
+BlogPostModel.find({}, function(err, posts) {
   if (err) return handleError(err);
-  
+
   console.log(JSON.stringify(posts)); // [{ _id: '...', title: 'Title 1 on default language' },
-                                      //  { _id: '...', title: 'Title 2 on default language' }, ...]
-  
+  //  { _id: '...', title: 'Title 2 on default language' }, ...]
+
   BlogPostModel.getLanguages(); // [ 'en', 'de', 'fr' ]
   BlogPostModel.getDefaultLanguage(); // 'en'
-  
+
   BlogPostModel.setDefaultLanguage('de');
   console.log(JSON.stringify(posts)); // [{ _id: '...', title: 'Another German title 1' },
-                                      //  { _id: '...', title: 'Another German title 2' }, ...]
+  //  { _id: '...', title: 'Another German title 2' }, ...]
 });
 ```
 
-*Note:* `BlogPostModel.setDefaultLanguage();` method changes language settings on the schema level, it means that in case you have couple models sharing the same schema, language change will be applied to all other models as well.
+_Note:_ `BlogPostModel.setDefaultLanguage();` method changes language settings on the schema level, it means that in case you have couple models sharing the same schema, language change will be applied to all other models as well.
 
 #### Connection level
 
 One more global method to change the language for all your schemas:
-* `setDefaultLanguage(lang)` - updates all schemas for the Mongoose db connection
+
+- `setDefaultLanguage(lang)` - updates all schemas for the Mongoose db connection
 
 If you're creating connection explicitly:
+
 ```js
-var db = mongoose.createConnection('mongodb://user:pass@localhost:port/database');
+var db = mongoose.createConnection(
+  'mongodb://user:pass@localhost:port/database'
+);
 
 db.setDefaultLanguage('de');
 ```
+
 or using the default connection:
+
 ```js
 mongoose.connect('mongodb://user:pass@localhost:port/database');
 
@@ -248,18 +265,20 @@ Schema- and Connection-level methods are actually changing schema's settings, wh
 mongoose.setDefaultLanguage(userLang);
 
 // .find() method is async and callback function can be executed during another event loop
-BlogPostModel.find({}, function (err, posts) {
+BlogPostModel.find({}, function(err, posts) {
   if (err) return handleError(err);
-  
+
   response.write(JSON.stringify(posts));
   response.end();
 });
 ```
+
 If we'll have 2 users that are using different languages, and are sending simultaneous requests, than it can be possible that the code above will return the response on the same language for both of them.
 
 Correct usage:
+
 ```js
-BlogPostModel.find({}, function (err, posts) {
+BlogPostModel.find({}, function(err, posts) {
   if (err) return handleError(err);
 
   mongoose.setDefaultLanguage(userLang);
@@ -278,8 +297,13 @@ Example:
 
 ```js
 var BlogPost = new Schema({
-    title  : { type: String, intl: true, default: 'Some default title', requiredAll: true },
-    body   : { type: String, intl: true }
+  title: {
+    type: String,
+    intl: true,
+    default: 'Some default title',
+    requiredAll: true
+  },
+  body: { type: String, intl: true }
 });
 ```
 
@@ -290,32 +314,38 @@ But please be careful with some of them like `enum` which may not be relevant fo
 
 `v3.x` drops support of `field.all` get/set methods. Virtual paths with the dots inside are not ignored since Mongoose v4.11.5 (see [#5473](https://github.com/Automattic/mongoose/issues/5473)). And `field.all` overrides `field` value which is not expected.
 TO set values, instead of
+
 ```js
 post.set('title.all', {
-    en: '...',
-    de: '...'
+  en: '...',
+  de: '...'
 });
 ```
+
 use
+
 ```js
 post.title = {
-    en: '...',
-    de: '...'
+  en: '...',
+  de: '...'
 };
 ```
 
 To read the entire language document or the current language only, disable or enable virtuals for `toJSON/toObject` methods.
+
 ## Upgrading from v1.x to v2.x
 
 `v2.x` version has incompatible API updates for Mongoose document language methods:
-* `getDefaultLanguage()` - was renamed to `getLanguage()`
-* `setDefaultLanguage(lang)` - was renamed to `setLanguage(lang)`
+
+- `getDefaultLanguage()` - was renamed to `getLanguage()`
+- `setDefaultLanguage(lang)` - was renamed to `setLanguage(lang)`
 
 `*DefaultLanguage` methods are not available for the documents any more, they are used for the schema settings changes now.
 
 So in the example from `v1.x` documentation:
+
 ```js
-BlogPostModel.findById('some id', function (err, post) {
+BlogPostModel.findById('some id', function(err, post) {
   if (err) return handleError(err);
 
   console.log(post.toJSON()); // { _id: '...', title: 'Title on default language', body: '...' }
@@ -325,12 +355,13 @@ BlogPostModel.findById('some id', function (err, post) {
 
   post.setDefaultLanguage('de');
   console.log(post.toJSON()); // { _id: '...', title: 'Another German title', body: '...' }
-
 });
 ```
+
 `Default` prefix should be removed from the getter and setter:
+
 ```js
-BlogPostModel.findById('some id', function (err, post) {
+BlogPostModel.findById('some id', function(err, post) {
   if (err) return handleError(err);
 
   console.log(post.toJSON()); // { _id: '...', title: 'Title on default language', body: '...' }
@@ -340,6 +371,5 @@ BlogPostModel.findById('some id', function (err, post) {
 
   post.setLanguage('de');
   console.log(post.toJSON()); // { _id: '...', title: 'Another German title', body: '...' }
-
 });
 ```

--- a/lib/mongoose-intl.js
+++ b/lib/mongoose-intl.js
@@ -1,195 +1,209 @@
 'use strict';
 
 var mongoose = require('mongoose'),
-    extend   = require('util')._extend;
+  extend = require('util')._extend;
 
 module.exports = exports = function mongooseIntl(schema, options) {
-    if (!options || !options.languages || !Array.isArray(options.languages) || !options.languages.length) {
-        throw new mongoose.Error('Required languages array is missing');
+  if (
+    !options ||
+    !options.languages ||
+    !Array.isArray(options.languages) ||
+    !options.languages.length
+  ) {
+    throw new mongoose.Error('Required languages array is missing');
+  }
+
+  // plugin options to be set under schema options
+  schema.options.mongooseIntl = {};
+  var pluginOptions = schema.options.mongooseIntl;
+
+  pluginOptions.languages = options.languages.slice(0);
+
+  // the first available language will be used as default if it's not set or unknown value passed
+  if (
+    !options.defaultLanguage ||
+    pluginOptions.languages.indexOf(options.defaultLanguage) === -1
+  ) {
+    pluginOptions.defaultLanguage = pluginOptions.languages[0];
+  } else {
+    pluginOptions.defaultLanguage = options.defaultLanguage.slice(0);
+  }
+
+  schema.eachPath(function(path, schemaType) {
+    if (schemaType.schema) {
+      // propagate plugin initialization for sub-documents schemas
+      schemaType.schema.plugin(mongooseIntl, pluginOptions);
+      return;
     }
 
-    // plugin options to be set under schema options
-    schema.options.mongooseIntl = {};
-    var pluginOptions = schema.options.mongooseIntl;
-
-    pluginOptions.languages = options.languages.slice(0);
-
-    // the first available language will be used as default if it's not set or unknown value passed
-    if (!options.defaultLanguage || pluginOptions.languages.indexOf(options.defaultLanguage) === -1) {
-        pluginOptions.defaultLanguage = pluginOptions.languages[0];
-    } else {
-        pluginOptions.defaultLanguage = options.defaultLanguage.slice(0);
+    if (!schemaType.options.intl) {
+      return;
     }
 
-    schema.eachPath(function (path, schemaType) {
-        if (schemaType.schema) { // propagate plugin initialization for sub-documents schemas
-            schemaType.schema.plugin(mongooseIntl, pluginOptions);
-            return;
+    if (!(schemaType instanceof mongoose.Schema.Types.String)) {
+      throw new mongoose.Error(
+        'Mongoose-intl plugin can be used with String type only'
+      );
+    }
+
+    var pathArray = path.split('.'),
+      key = pathArray.pop(),
+      prefix = pathArray.join('.');
+
+    if (prefix) prefix += '.';
+
+    // removing real path, it will be changed to virtual later
+    schema.remove(path);
+
+    // schema.remove removes path from paths object only, but doesn't update tree
+    // sounds like a bug, removing item from the tree manually
+    var tree = pathArray.reduce(function(mem, part) {
+      return mem[part];
+    }, schema.tree);
+    delete tree[key];
+
+    schema
+      .virtual(path)
+      .get(function() {
+        // embedded and sub-documents will use language methods from the top level document
+        var owner = this.ownerDocument ? this.ownerDocument() : this,
+          lang = owner.getLanguage(),
+          langSubDoc = (this.$__getValue || this.getValue).call(this, path);
+
+        if (langSubDoc === null || langSubDoc === void 0) {
+          return langSubDoc;
         }
 
-        if (!schemaType.options.intl) {
-            return;
+        if (options.virtualObject) return langSubDoc;
+
+        if (langSubDoc.hasOwnProperty(lang)) {
+          return langSubDoc[lang];
         }
 
-        if (!(schemaType instanceof mongoose.Schema.Types.String)) {
-            throw new mongoose.Error('Mongoose-intl plugin can be used with String type only');
+        // are there any other languages defined?
+        for (var prop in langSubDoc) {
+          if (langSubDoc.hasOwnProperty(prop)) {
+            return null; // some other languages exist, but the required is not - return null value
+          }
+        }
+        return void 0; // no languages defined - the entire field is undefined
+      })
+      .set(function(value) {
+        // multiple languages are set as an object
+        if (typeof value === 'object') {
+          var languages = this.schema.options.mongooseIntl.languages;
+          languages.forEach(function(lang) {
+            if (!value[lang]) {
+              return;
+            }
+            this.set(path + '.' + lang, value[lang]);
+          }, this);
+          return;
         }
 
-        var pathArray = path.split('.'),
-            key       = pathArray.pop(),
-            prefix    = pathArray.join('.');
+        // embedded and sub-documents will use language methods from the top level document
+        var owner = this.ownerDocument ? this.ownerDocument() : this;
+        this.set(path + '.' + owner.getLanguage(), value);
+      });
 
-        if (prefix) prefix += '.';
+    // intl option is not needed for the current path any more,
+    // and is unwanted for all child lang-properties
+    delete schemaType.options.intl;
 
-        // removing real path, it will be changed to virtual later
-        schema.remove(path);
+    var intlObject = {};
+    intlObject[key] = {};
+    pluginOptions.languages.forEach(function(lang) {
+      var langOptions = extend({}, schemaType.options);
+      if (lang !== options.defaultLanguage) {
+        delete langOptions.default;
+        delete langOptions.required;
+      }
 
-        // schema.remove removes path from paths object only, but doesn't update tree
-        // sounds like a bug, removing item from the tree manually
-        var tree = pathArray.reduce(function (mem, part) {
-            return mem[part];
-        }, schema.tree);
-        delete tree[key];
+      if (schemaType.options.defaultAll) {
+        langOptions.default = schemaType.options.defaultAll;
+      }
 
+      if (schemaType.options.requiredAll) {
+        langOptions.required = schemaType.options.requiredAll;
+      }
+      this[lang] = langOptions;
+    }, intlObject[key]);
 
-        schema.virtual(path)
-            .get(function () {
-                // embedded and sub-documents will use language methods from the top level document
-                var owner = this.ownerDocument ? this.ownerDocument() : this,
-                    lang = owner.getLanguage(),
-                    langSubDoc = (this.$__getValue || this.getValue).call(this, path);
+    // intlObject example:
+    // { fieldName: {
+    //     en: '',
+    //     de: ''
+    // }}
+    schema.add(intlObject, prefix);
+  });
 
-                if (langSubDoc === null || langSubDoc === void 0) {
-                    return langSubDoc;
-                }
+  // document methods to set the language for each model instance (document)
+  schema.method({
+    getLanguages: function() {
+      return this.schema.options.mongooseIntl.languages;
+    },
+    getLanguage: function() {
+      return (
+        this.docLanguage || this.schema.options.mongooseIntl.defaultLanguage
+      );
+    },
+    setLanguage: function(lang) {
+      if (lang && this.getLanguages().indexOf(lang) !== -1) {
+        this.docLanguage = lang;
+      }
+    },
+    unsetLanguage: function() {
+      delete this.docLanguage;
+    }
+  });
 
-                if (langSubDoc.hasOwnProperty(lang)) {
-                    return langSubDoc[lang];
-                }
+  // model methods to set the language for the current schema
+  schema.static({
+    getLanguages: function() {
+      return this.schema.options.mongooseIntl.languages;
+    },
+    getDefaultLanguage: function() {
+      return this.schema.options.mongooseIntl.defaultLanguage;
+    },
+    setDefaultLanguage: function(lang) {
+      function updateLanguage(schema, lang) {
+        schema.options.mongooseIntl.defaultLanguage = lang.slice(0);
 
-                // are there any other languages defined?
-                for (var prop in langSubDoc) {
-                    if (langSubDoc.hasOwnProperty(prop)) {
-                        return null; // some other languages exist, but the required is not - return null value
-                    }
-                }
-                return void 0; // no languages defined - the entire field is undefined
-            })
-            .set(function (value) {
-                // multiple languages are set as an object
-                if (typeof value === 'object') {
-                    var languages = this.schema.options.mongooseIntl.languages;
-                    languages.forEach(function (lang) {
-                        if (!value[lang]) { return; }
-                        this.set(path + '.' + lang, value[lang]);
-                    }, this);
-                    return;
-                }
+        // default language change for sub-documents schemas
+        schema.eachPath(function(path, schemaType) {
+          if (schemaType.schema) {
+            updateLanguage(schemaType.schema, lang);
+          }
+        });
+      }
+      if (lang && this.getLanguages().indexOf(lang) !== -1) {
+        updateLanguage(this.schema, lang);
+      }
+    }
+  });
 
-                // embedded and sub-documents will use language methods from the top level document
-                var owner = this.ownerDocument ? this.ownerDocument() : this;
-                this.set(path + '.' + owner.getLanguage(), value);
-            });
+  // Mongoose will emit 'init' event once the schema will be attached to the model
+  schema.on('init', function(model) {
+    // no actions are required in the global method is already defined
+    if (model.db.setDefaultLanguage) {
+      return;
+    }
 
-
-        // intl option is not needed for the current path any more,
-        // and is unwanted for all child lang-properties
-        delete schemaType.options.intl;
-
-        var intlObject = {};
-        intlObject[key] = {};
-        pluginOptions.languages.forEach(function (lang) {
-            var langOptions = extend({}, schemaType.options);
-            if (lang !== options.defaultLanguage) {
-                delete langOptions.default;
-                delete langOptions.required;
-            }
-
-            if (schemaType.options.defaultAll) {
-                langOptions.default = schemaType.options.defaultAll;
-            }
-
-            if (schemaType.options.requiredAll) {
-                langOptions.required = schemaType.options.requiredAll;
-            }
-            this[lang] = langOptions;
-        }, intlObject[key]);
-
-        // intlObject example:
-        // { fieldName: {
-        //     en: '',
-        //     de: ''
-        // }}
-        schema.add(intlObject, prefix);
-    });
-
-    // document methods to set the language for each model instance (document)
-    schema.method({
-        getLanguages: function () {
-            return this.schema.options.mongooseIntl.languages;
-        },
-        getLanguage: function () {
-            return this.docLanguage || this.schema.options.mongooseIntl.defaultLanguage;
-        },
-        setLanguage: function (lang) {
-            if (lang && this.getLanguages().indexOf(lang) !== -1) {
-                this.docLanguage = lang;
-            }
-        },
-        unsetLanguage: function () {
-            delete this.docLanguage;
+    // define a global method to change the language for all models (and their schemas)
+    // created for the current mongo connection
+    model.db.setDefaultLanguage = function(lang) {
+      var model, modelName;
+      for (modelName in this.models) {
+        if (this.models.hasOwnProperty(modelName)) {
+          model = this.models[modelName];
+          model.setDefaultLanguage && model.setDefaultLanguage(lang);
         }
-    });
+      }
+    };
 
-    // model methods to set the language for the current schema
-    schema.static({
-        getLanguages: function () {
-            return this.schema.options.mongooseIntl.languages;
-        },
-        getDefaultLanguage: function () {
-            return this.schema.options.mongooseIntl.defaultLanguage;
-        },
-        setDefaultLanguage: function (lang) {
-
-            function updateLanguage(schema, lang) {
-                schema.options.mongooseIntl.defaultLanguage = lang.slice(0);
-
-                // default language change for sub-documents schemas
-                schema.eachPath(function (path, schemaType) {
-                    if (schemaType.schema) {
-                        updateLanguage(schemaType.schema, lang);
-                    }
-                });
-
-            }
-            if (lang && this.getLanguages().indexOf(lang) !== -1) {
-                updateLanguage(this.schema, lang);
-            }
-        }
-    });
-
-    // Mongoose will emit 'init' event once the schema will be attached to the model
-    schema.on('init', function (model) {
-        // no actions are required in the global method is already defined
-        if (model.db.setDefaultLanguage) {
-            return;
-        }
-
-        // define a global method to change the language for all models (and their schemas)
-        // created for the current mongo connection
-        model.db.setDefaultLanguage = function (lang) {
-            var model, modelName;
-            for (modelName in this.models) {
-                if (this.models.hasOwnProperty(modelName)) {
-                    model = this.models[modelName];
-                    model.setDefaultLanguage && model.setDefaultLanguage(lang);
-                }
-            }
-        };
-
-        // create an alias for the global change language method attached to the default connection
-        if (!mongoose.setDefaultLanguage) {
-            mongoose.setDefaultLanguage = mongoose.connection.setDefaultLanguage;
-        }
-    });
+    // create an alias for the global change language method attached to the default connection
+    if (!mongoose.setDefaultLanguage) {
+      mongoose.setDefaultLanguage = mongoose.connection.setDefaultLanguage;
+    }
+  });
 };


### PR DESCRIPTION
This change only send the option 'virtualObject' in the plugin options, so when we use:
 toJSON: { virtuals: true }, toObject: { virtuals: true }, it still send the full language object and not only the primary language string.