### PR TITLE
Support Mongoose v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "peerDependencies": {
-    "mongoose": "~4 || ~5"
+    "mongoose": "~4 || ~5 || ~6"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
At a quick glance, I don't see anything in the [Mongoose 6.x migration guide](https://mongoosejs.com/docs/migrating_to_6.html) that looks like it would affect this plugin. Tests in my (closed source) project that is using it don't indicate any issues.

See also: [Mongoose v6 changelog](https://github.com/Automattic/mongoose/blob/6.0.0/CHANGELOG.md)